### PR TITLE
OCaml support + better shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Run everything like a script!
 - Python    (python)
 - GNU Octave    (octave)
 - Intel Assembly (nasm)
+- OCaml (ocamlopt)
 
 ### Installation
 ```sh

--- a/execute
+++ b/execute
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 # execute
 #
@@ -157,6 +157,10 @@ def main():
     elif e in (".vala", ".gs"):
         b = "\'" + bp + n + ".bin" + "\'"
         cm = "valac " + inputFiles + " -o " + b
+        rn = b
+    elif e in (".ml"):
+        b = "\'" + bp + n + ".bin" + "\'"
+        cm = "ocamlopt " + inputFiles + " -o " + b
         rn = b
     elif e == ".c":
         b = "\'" + bp + n + ".bin" + "\'"


### PR DESCRIPTION
i had issues while trying to execute "execute", since my python is in /usr/bin/ for some reason, so i changed the shebang of "execute".

Also, i added an "elif" for .ml files support (compiled with ocamlopt), and it seems to work (however i didn't commit a test file for that).